### PR TITLE
Revise getRandom facilities

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -720,6 +720,7 @@ AC_CHECK_FUNCS([__argz_count \
                 gethostbyname \
 		getifaddrs \
                 getpagesize \
+                getrandom \
                 memchr \
                 memmove \
                 mempcpy \
@@ -754,6 +755,19 @@ AC_CHECK_FUNCS([__argz_count \
                 usleep \
 		utime \
 		utimes])
+
+AC_MSG_CHECKING([for getrandom linux syscall interface])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <linux/random.h>
+]],
+[[
+int x = GRND_NONBLOCK;
+]])],
+  [have_getrandom_interface=yes
+   AC_DEFINE([HAVE_GETRANDOM_INTERFACE], [1], [Define to 1 if getrandom linux syscall interface is available.])],
+  [have_getrandom_interface=no])
+AC_MSG_RESULT([$have_getrandom_interface])
+AM_CONDITIONAL([HAVE_GETRANDOM_INTERFACE], [test "x$have_getrandom_interface" = "xyes"])
 
 dnl Put tcmalloc/jemalloc checks after the posix_memalign check.
 dnl These libraries may implement posix_memalign, while the usual CRT may not

--- a/src/Context.cc
+++ b/src/Context.cc
@@ -163,7 +163,6 @@ Context::Context(bool standalone,
       throw DL_ABORT_EX("Option processing failed");
     }
   }
-  SimpleRandomizer::getInstance()->init();
 #ifdef ENABLE_BITTORRENT
   bittorrent::generateStaticPeerId(op->get(PREF_PEER_ID_PREFIX));
 #endif // ENABLE_BITTORRENT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -687,6 +687,10 @@ if HAVE_KQUEUE
 SRCS += KqueueEventPoll.cc KqueueEventPoll.h
 endif # HAVE_KQUEUE
 
+if HAVE_GETRANDOM_INTERFACE
+SRCS += getrandom_linux.c getrandom_linux.h
+endif # HAVE_GETRANDOM_INTERFACE
+
 if HAVE_LIBUV
 SRCS += LibuvEventPoll.cc LibuvEventPoll.h
 endif # HAVE_LIBUV

--- a/src/SimpleRandomizer.cc
+++ b/src/SimpleRandomizer.cc
@@ -92,7 +92,7 @@ void SimpleRandomizer::getRandomBytes(unsigned char* buf, size_t len)
   auto rv = getrandom_linux(buf, len);
   assert(rv >= 0 && (size_t)rv == len);
 #else // ! __MINGW32__
-  result_type* ubuf = reinterpret_cast<result_type*>(buf);
+  auto ubuf = reinterpret_cast<result_type*>(buf);
   size_t q = len / sizeof(result_type);
   auto gen = std::uniform_int_distribution<result_type>();
   for(; q > 0; --q, ++ubuf) {

--- a/src/SimpleRandomizer.h
+++ b/src/SimpleRandomizer.h
@@ -54,7 +54,9 @@ private:
 private:
 #ifdef __MINGW32__
   HCRYPTPROV provider_;
-#else // ! __MINGW32__
+#elif defined(HAVE_GETRANDOM_INTERFACE)
+  // Nothing special needed
+#else
   std::random_device dev_;
 #endif // ! __MINGW32__
 
@@ -63,7 +65,7 @@ public:
 
   static const std::unique_ptr<SimpleRandomizer>& getInstance();
 
-  ~SimpleRandomizer();
+  virtual ~SimpleRandomizer();
 
   /**
    * Returns random number in [0, to).

--- a/src/getrandom_linux.h
+++ b/src/getrandom_linux.h
@@ -2,7 +2,7 @@
 /*
  * aria2 - The high speed download utility
  *
- * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ * Copyright (C) 2014 Nils Maier
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,74 +32,18 @@
  * files in the program, then also delete it here.
  */
 /* copyright --> */
-#ifndef D_SIMPLE_RANDOMIZER_H
-#define D_SIMPLE_RANDOMIZER_H
 
-#include "Randomizer.h"
+#ifndef D_GETRANDOM_LINUX_H
+#define D_GETRANDOM_LINUX_H
 
-#include <memory>
-#include <random>
-
-#ifdef __MINGW32__
-#  include <wincrypt.h>
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-namespace aria2 {
+int getrandom_linux(void *buf, size_t buflen);
 
-class SimpleRandomizer : public Randomizer {
-private:
-  static std::unique_ptr<SimpleRandomizer> randomizer_;
-  SimpleRandomizer();
+#ifdef __cplusplus
+}
+#endif
 
-private:
-#ifdef __MINGW32__
-  HCRYPTPROV provider_;
-#else // ! __MINGW32__
-  std::random_device dev_;
-#endif // ! __MINGW32__
-
-public:
-  typedef std::random_device::result_type result_type;
-
-  static const std::unique_ptr<SimpleRandomizer>& getInstance();
-
-  ~SimpleRandomizer();
-
-  /**
-   * Returns random number in [0, to).
-   */
-  virtual long int getRandomNumber(long int to) CXX11_OVERRIDE;
-
-  void getRandomBytes(unsigned char *buf, size_t len);
-
-  long int operator()(long int to)
-  {
-    return getRandomNumber(to);
-  }
-
-  result_type operator()()
-  {
-    result_type rv;
-    getRandomBytes(reinterpret_cast<unsigned char*>(&rv), sizeof(rv));
-    return rv;
-  }
-
-  static constexpr result_type min()
-  {
-    return std::numeric_limits<result_type>::min();
-  }
-
-  static constexpr result_type max()
-  {
-    return std::numeric_limits<result_type>::max();
-  }
-
-  static double entropy()
-  {
-    return 0.0;
-  }
-};
-
-} // namespace aria2
-
-#endif // D_SIMPLE_RANDOMIZER_H
+#endif /* D_GETRANDOM_LINUX_H */

--- a/src/util.cc
+++ b/src/util.cc
@@ -1545,45 +1545,10 @@ std::vector<std::pair<size_t, std::string> > createIndexPaths(std::istream& i)
   return indexPaths;
 }
 
-namespace {
-void generateRandomDataRandom(unsigned char* data, size_t length)
-{
-  const auto& rd = SimpleRandomizer::getInstance();
-  rd->getRandomBytes(data, length);
-}
-} // namespace
-
-#ifndef __MINGW32__
-namespace {
-void generateRandomDataUrandom
-(unsigned char* data, size_t length, std::ifstream& devUrand)
-{
-  devUrand.read(reinterpret_cast<char*>(data), length);
-}
-} // namespace
-#endif
-
 void generateRandomData(unsigned char* data, size_t length)
 {
-#ifdef __MINGW32__
-  generateRandomDataRandom(data, length);
-#else // !__MINGW32__
-  static int method = -1;
-  static std::ifstream devUrand;
-  if(method == 0) {
-    generateRandomDataUrandom(data, length, devUrand);
-  } else if(method == 1) {
-    generateRandomDataRandom(data, length);
-  } else {
-    devUrand.open("/dev/urandom");
-    if(devUrand) {
-      method = 0;
-    } else {
-      method = 1;
-    }
-    generateRandomData(data, length);
-  }
-#endif // !__MINGW32__
+  const auto& rd = SimpleRandomizer::getInstance();
+  return rd->getRandomBytes(data, length);
 }
 
 bool saveAs


### PR DESCRIPTION
Use one of the following to provide random bytes:
- Windows CryptGenRandom
- Linux getrandom (syscall interface to urandom, without nasty corner
  cases such as file descriptor exhaustion or re-linked /dev/urandom)
- std::device_random (C++ random device, which usually will be urandom)

This also equalizes util::getRandom and SimpleRandomizer (the former
will now use the latter) instead of having essentially two different
PRNG interfaces with potentially different quality.