### PR TITLE
Assertion failed in SimpleRandomizer.cc:93

### DIFF
--- a/src/SimpleRandomizer.cc
+++ b/src/SimpleRandomizer.cc
@@ -42,6 +42,7 @@
 
 #include "a2time.h"
 #include "a2functional.h"
+#include "LogFactory.h"
 
 #ifdef HAVE_GETRANDOM_INTERFACE
 #  include "getrandom_linux.h"
@@ -88,10 +89,21 @@ void SimpleRandomizer::getRandomBytes(unsigned char* buf, size_t len)
 #ifdef __MINGW32__
   BOOL r = CryptGenRandom(provider_, len, reinterpret_cast<BYTE*>(buf));
   assert(r);
-#elif defined(HAVE_GETRANDOM_INTERFACE)
-  auto rv = getrandom_linux(buf, len);
-  assert(rv >= 0 && (size_t)rv == len);
 #else // ! __MINGW32__
+#if defined(HAVE_GETRANDOM_INTERFACE)
+  static bool have_random_support = true;
+  if (have_random_support) {
+    auto rv = getrandom_linux(buf, len);
+    if (rv != -ENOSYS) {
+        assert(rv >= 0 && (size_t)rv == len);
+      return;
+    }
+    have_random_support = false;
+    A2_LOG_INFO("Disabled getrandom support, because kernel does not "\
+        "implement this feature (ENOSYS)");
+  }
+  // Fall through to generic implementation
+#endif // defined(HAVE_GETRANDOM_INTERFACE)
   auto ubuf = reinterpret_cast<result_type*>(buf);
   size_t q = len / sizeof(result_type);
   auto gen = std::uniform_int_distribution<result_type>();

--- a/src/SimpleRandomizer.h
+++ b/src/SimpleRandomizer.h
@@ -54,8 +54,6 @@ private:
 private:
 #ifdef __MINGW32__
   HCRYPTPROV provider_;
-#elif defined(HAVE_GETRANDOM_INTERFACE)
-  // Nothing special needed
 #else
   std::random_device dev_;
 #endif // ! __MINGW32__

--- a/src/getrandom_linux.c
+++ b/src/getrandom_linux.c
@@ -37,14 +37,45 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <linux/random.h>
+#include <errno.h>
+#include <linux/errno.h>
+#include <stdint.h>
+#include <stdio.h>
 
 #include "config.h"
 #include "getrandom_linux.h"
 
+
 int getrandom_linux(void *buf, size_t buflen) {
+  int rv = 0;
+  uint8_t* p = buf;
+  while (buflen) {
+    int read;
 #ifdef HAVE_GETRANDOM
-  return getrandom(buf, buflen, 0);
+    read = getrandom(p, buflen, 0);
 #else // HAVE_GETRANDOM
-  return syscall(SYS_getrandom, buf, buflen, 0);
+    read = syscall(SYS_getrandom, p, buflen, 0);
+    /* Some libc impl. might mess this up */
+    if (read == -EINTR || read == -ERESTART) {
+      errno = EINTR;
+      read = -1;
+    }
+    if (read < -1) {
+      errno = -read;
+      read = -1;
+    }
 #endif // HAVE_GETRANDOM
+    if (read < 0) {
+      int err = errno;
+      if (err == EINTR) {
+        continue;
+      }
+      fprintf(stderr, "getrandom returned an unhandled error: %d\n", err);
+      return read;
+    }
+    p += read;
+    rv += read;
+    buflen -= read;
+  }
+  return rv;
 }

--- a/src/getrandom_linux.c
+++ b/src/getrandom_linux.c
@@ -70,8 +70,10 @@ int getrandom_linux(void *buf, size_t buflen) {
       if (err == EINTR) {
         continue;
       }
-      fprintf(stderr, "getrandom returned an unhandled error: %d\n", err);
-      return read;
+      if (err != ENOSYS) {
+        fprintf(stderr, "getrandom returned an unhandled error: %d\n", err);
+      }
+      return -err;
     }
     p += read;
     rv += read;


### PR DESCRIPTION
When I try to download any file, I get this error: 
```
aria2c: SimpleRandomizer.cc:93: void aria2::SimpleRandomizer::getRandomBytes(unsigned char*, size_t): Assertion `rv >= 0 && (size_t)rv == len' failed.
---------
=> aria2c --version 
aria2 version 1.18.9
Copyright (C) 2006, 2014 Tatsuhiro Tsujikawa

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

** Configuration **
Enabled Features: Async DNS, BitTorrent, Firefox3 Cookie, GZip, HTTPS, Message Digest, Metalink, XML-RPC
Hash Algorithms: sha-1, sha-224, sha-256, sha-384, sha-512, md5, adler32
Libraries: zlib/1.2.8 libxml2/2.9.2 sqlite3/3.8.8.1 GnuTLS/3.3.12 nettle GMP/6.0.0 c-ares/1.10.0
Compiler: gcc 4.9.2 20141224 (prerelease)
  built by   x86_64-unknown-linux-gnu
  on         Feb  2 2015 08:14:18
System: Linux 3.15.8-1-ARCH #1 SMP PREEMPT Fri Aug 1 08:51:42 CEST 2014 x86_64

Report bugs to https://github.com/tatsuhiro-t/aria2/issues
Visit http://aria2.sourceforge.net/
--------
```
Let me know if any further data or log is needed.