### PR TITLE
Fix build issues with MinGW-w64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,9 +29,10 @@ case "$host" in
   *mingw*)
     win_build=yes
     LIBS="$LIBS -lws2_32 -lwsock32 -lgdi32 -lwinmm -liphlpapi -lpsapi"
-    # C++ headers defines __USE_MINGW_ANSI_STDIO to 1 unconditionally.
-    # We have to use it as well nonetheless.
-    CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1 $CPPFLAGS"
+    # Define _POSIX_C_SOURCE to 1. This makes {asc,local}time_r available
+    # from <time.h> even without (un)helpful interference from <pthread.h>,
+    # and also defines __USE_MINGW_ANSI_STDIO.
+    CPPFLAGS="-D_POSIX_C_SOURCE=1 $CPPFLAGS"
     # Build with ASLR (dynamicbase) and NX compatiblity (nxcompat)
     # Enable pie once upstream/binutils gets fixed to produce correct binaries with it.
     LDFLAGS="$LDFLAGS -Wl,--dynamicbase -Wl,--nxcompat"
@@ -841,10 +842,32 @@ AM_CONDITIONAL([HAVE_SOME_FALLOCATE],
   [test "x$have_posix_fallocate" = "xyes" || test "x$have_fallocate" = "xyes" \
   || test "x$have_osx" = "xyes" || test "x$win_build" = "xyes"])
 
+AC_MSG_CHECKING([for asctime_r])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #include <time.h>
+  ]], [[
+    struct tm r; char *c;
+    asctime_r(&r, c);
+  ]])],
+  [AM_CONDITIONAL([HAVE_ASCTIME_R], true)
+   AC_MSG_RESULT([yes])
+   AC_DEFINE([HAVE_ASCTIME_R], [1], [Define to 1 if you have the `asctime_r' function or macro.])],
+  [AC_MSG_RESULT([no])
+   AM_CONDITIONAL([HAVE_ASCTIME_R], false)])
 
-AC_CHECK_FUNCS([asctime_r],
-	[AM_CONDITIONAL([HAVE_ASCTIME_R], true)],
-	[AM_CONDITIONAL([HAVE_ASCTIME_R], false)])
+AC_MSG_CHECKING([for localtime_r])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #include <time.h>
+  ]], [[
+    time_t t; struct tm r;
+    localtime_r(&t, &r);
+  ]])],
+  [AM_CONDITIONAL([HAVE_LOCALTIME_R], true)
+   AC_MSG_RESULT([yes])
+   AC_DEFINE([HAVE_LOCALTIME_R], [1], [Define to 1 if you have the `localtime_r' function or macro.])],
+  [AC_MSG_RESULT([no])
+   AM_CONDITIONAL([HAVE_LOCALTIME_R], false)])
+
 AC_CHECK_FUNCS([basename],
 	[AM_CONDITIONAL([HAVE_BASENAME], true)],
 	[AM_CONDITIONAL([HAVE_BASENAME], false)])
@@ -857,9 +880,6 @@ AC_CHECK_FUNCS([getaddrinfo],
 AC_CHECK_FUNCS([gettimeofday],
 	[AM_CONDITIONAL([HAVE_GETTIMEOFDAY], true)],
 	[AM_CONDITIONAL([HAVE_GETTIMEOFDAY], false)])
-AC_CHECK_FUNCS([localtime_r],
-	[AM_CONDITIONAL([HAVE_LOCALTIME_R], true)],
-	[AM_CONDITIONAL([HAVE_LOCALTIME_R], false)])
 AC_CHECK_FUNCS([strptime],
 	[AM_CONDITIONAL([HAVE_STRPTIME], true)],
 	[AM_CONDITIONAL([HAVE_STRPTIME], false)])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -713,9 +713,9 @@ endif # !ENABLE_LIBARIA2
 
 libaria2_la_SOURCES = $(SRCS)
 
-libaria2_la_LIBADD = @WSLAY_LIBS@
+libaria2_la_LIBADD = @WSLAY_LIBS@ @LTLIBINTL@
 
-LDADD = libaria2.la @LIBINTL@ @ALLOCA@ #-lprofiler
+LDADD = libaria2.la @ALLOCA@ #-lprofiler
 #aria2c_LDFLAGS = -pg
 AM_CPPFLAGS =  -Wall\
 	-I$(top_srcdir)/lib -I$(top_srcdir)/intl\


### PR DESCRIPTION
These commits fix two build issues on MinGW-w64 (using MSYS2, to be precise). I can't guarantee they don't break builds on regular mingw.org or Linux, but hopefully they don't.

Comments welcome.