### PR TITLE
Allow netrc-path to be specified in the config file

### DIFF
--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1513,8 +1513,6 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
                        util::getHomeDir()+"/.netrc",
                        PATH_TO_FILE));
     op->setInitialOption(true);
-    op->setChangeGlobalOption(true);
-    op->setChangeOptionForReserved(true);
     handlers.push_back(op);
   }
   // Proxy options

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1512,7 +1512,9 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
                        NO_DESCRIPTION,
                        util::getHomeDir()+"/.netrc",
                        PATH_TO_FILE));
-    op->hide();
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
     handlers.push_back(op);
   }
   // Proxy options

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -225,8 +225,6 @@
   _(" -U, --user-agent=USER_AGENT  Set user agent for http(s) downloads.")
 #define TEXT_NO_NETRC                                           \
   _(" -n, --no-netrc[=true|false]  Disables netrc support.")
-#define TEXT_NETRC_PATH                                           \
-  _(" -n, --netrc-path=FILE        Specify the path to the netrc file.")
 #define TEXT_INPUT_FILE                                                 \
   _(" -i, --input-file=FILE        Downloads URIs found in FILE. You can specify\n" \
     "                              multiple URIs for a single entity: separate\n" \

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -225,6 +225,8 @@
   _(" -U, --user-agent=USER_AGENT  Set user agent for http(s) downloads.")
 #define TEXT_NO_NETRC                                           \
   _(" -n, --no-netrc[=true|false]  Disables netrc support.")
+#define TEXT_NETRC_PATH                                           \
+  _(" --netrc-path=FILE            Specify the path to the netrc file.")
 #define TEXT_INPUT_FILE                                                 \
   _(" -i, --input-file=FILE        Downloads URIs found in FILE. You can specify\n" \
     "                              multiple URIs for a single entity: separate\n" \

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -225,6 +225,8 @@
   _(" -U, --user-agent=USER_AGENT  Set user agent for http(s) downloads.")
 #define TEXT_NO_NETRC                                           \
   _(" -n, --no-netrc[=true|false]  Disables netrc support.")
+#define TEXT_NETRC_PATH                                           \
+  _(" -n, --netrc-path=FILE        Specify the path to the netrc file.")
 #define TEXT_INPUT_FILE                                                 \
   _(" -i, --input-file=FILE        Downloads URIs found in FILE. You can specify\n" \
     "                              multiple URIs for a single entity: separate\n" \


### PR DESCRIPTION
Allow us to specify an alternate path for the netrc file.  By default, this option is hidden from us and defaults to HOME/.netrc