### PR TITLE
Make config and cache files conform to XDG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -429,9 +429,11 @@ DHT
 ~~~
 
 aria2 supports mainline compatible DHT. By default, the routing table
-for IPv4 DHT is saved to ``$HOME/.aria2/dht.dat`` and the routing
-table for IPv6 DHT is saved to ``$HOME/.aria2/dht6.dat``. aria2 uses
-same port number to listen on for both IPv4 and IPv6 DHT.
+for IPv4 DHT is saved to ``$XDG_CACHE_HOME/aria2/dht.dat`` and the
+routing table for IPv6 DHT is saved to
+``$XDG_CACHE_HOME/aria2/dht6.dat`` unless files exist at
+``$HOME/.aria2/dht.dat`` or ``$HOME/.aria2/dht6.dat``. aria2 uses same
+port number to listen on for both IPv4 and IPv6 DHT.
 
 UDP tracker
 ~~~~~~~~~~~

--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -801,12 +801,14 @@ BitTorrent Specific Options
 .. option:: --dht-file-path=<PATH>
 
   Change the IPv4 DHT routing table file to PATH.
-  Default: ``$HOME/.aria2/dht.dat``
+  Default: ``$HOME/.aria2/dht.dat`` if present, otherwise
+  ``$XDG_CACHE_HOME/aria2/dht.dat``.
 
 .. option:: --dht-file-path6=<PATH>
 
   Change the IPv6 DHT routing table file to PATH.
-  Default: ``$HOME/.aria2/dht6.dat``
+  Default: ``$HOME/.aria2/dht6.dat`` if present, otherwise
+  ``$XDG_CACHE_HOME/aria2/dht6.dat``.
 
 .. option:: --dht-listen-addr6=<ADDR>
 
@@ -1181,7 +1183,8 @@ Advanced Options
 .. option:: --conf-path=<PATH>
 
   Change the configuration file path to PATH.
-  Default: ``$HOME/.aria2/aria2.conf``
+  Default: ``$HOME/.aria2/aria2.conf`` if present, otherwise
+  ``$XDG_CONFIG_HOME/aria2/aria2.conf``.
 
 .. option:: --console-log-level=<LEVEL>
 
@@ -1839,10 +1842,12 @@ FILES
 aria2.conf
 ~~~~~~~~~~
 
-By default, aria2 parses ``$HOME/.aria2/aria2.conf`` as a
-configuration file. You can specify the path to configuration file
-using :option:`--conf-path` option.  If you don't want to use the
-configuration file, use :option:`--no-conf` option.
+By default, aria2 checks whether the legacy path
+``$HOME/.aria2/aria2.conf`` is present, otherwise it parses
+``$XDG_CONFIG_HOME/aria2/aria2.conf`` as its configuration file.  You
+can specify the path to configuration file using :option:`--conf-path`
+option.  If you don't want to use the configuration file, use
+:option:`--no-conf` option.
 
 The configuration file is a text file and has 1 option per each
 line. In each line, you can specify name-value pair in the format:
@@ -1867,9 +1872,11 @@ lines beginning ``#`` are treated as comments::
 dht.dat
 ~~~~~~~~
 
-By default, the routing table of IPv4 DHT is saved to the path
-``$HOME/.aria2/dht.dat`` and the routing table of IPv6 DHT is saved to
-the path ``$HOME/.aria2/dht6.dat``.
+Unless the legacy file paths ``$HOME/.aria2/dht.dat`` and
+``$HOME/.aria2/dht6.dat`` are pointing to existing files, the routing
+table of IPv4 DHT is saved to the path
+``$XDG_CACHE_HOME/aria2/dht.dat`` and the routing table of IPv6 DHT is
+saved to the path ``$XDG_CACHE_HOME/aria2/dht6.dat``.
 
 Netrc
 ~~~~~

--- a/doc/manual-src/en/technical-notes.rst
+++ b/doc/manual-src/en/technical-notes.rst
@@ -96,8 +96,10 @@ times.
 DHT routing table file format
 -----------------------------
 
-aria2 saves IPv4 DHT routing table in ``${HOME}/.aria2/dht.dat`` and
-IPv6 DHT routing table in ``${HOME}/.aria2/dht6.dat`` by default.
+aria2 saves IPv4 DHT routing table in
+``${XDG_CACHE_HOME}/aria2/dht.dat`` and IPv6 DHT routing table in
+``${XDG_CACHE_HOME}/aria2/dht6.dat`` by default unless
+``${HOME}/.aria2/dht.dat`` and ``${HOME}/.aria2/dht.dat`` are present.
 
 ``dht.dat`` and ``dht6.dat`` files use same binary encoding and have
 following fields. All multi byte integers are in network byte

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -174,7 +174,7 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     OptionHandler* op(new DefaultOptionHandler
                       (PREF_CONF_PATH,
                        TEXT_CONF_PATH,
-                       util::getHomeDir()+"/.aria2/aria2.conf",
+                       util::getConfigFile(),
                        PATH_TO_FILE));
     op->addTag(TAG_ADVANCED);
     handlers.push_back(op);
@@ -2043,7 +2043,7 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     OptionHandler* op(new DefaultOptionHandler
                       (PREF_DHT_FILE_PATH,
                        TEXT_DHT_FILE_PATH,
-                       util::getHomeDir()+"/.aria2/dht.dat",
+                       util::getDHTFile(false),
                        PATH_TO_FILE));
     op->addTag(TAG_BITTORRENT);
     handlers.push_back(op);
@@ -2052,7 +2052,7 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     OptionHandler* op(new DefaultOptionHandler
                       (PREF_DHT_FILE_PATH6,
                        TEXT_DHT_FILE_PATH6,
-                       util::getHomeDir()+"/.aria2/dht6.dat",
+                       util::getDHTFile(true),
                        PATH_TO_FILE));
     op->addTag(TAG_BITTORRENT);
     handlers.push_back(op);

--- a/src/util.cc
+++ b/src/util.cc
@@ -1336,6 +1336,37 @@ std::string getHomeDir()
 }
 #endif // __MINGW32__
 
+std::string getXDGDir(const std::string& environmentVariable,
+                      const std::string& fallbackDirectory)
+{
+  std::string filename;
+  const char* p = getenv(environmentVariable.c_str());
+  if (p && p[0] == '/') {
+    filename = p;
+  } else {
+    filename = fallbackDirectory;
+  }
+  return filename;
+}
+
+std::string getConfigFile() {
+  std::string filename = getHomeDir() + "/.aria2/aria2.conf";
+  if (!File(filename).exists()) {
+      filename = getXDGDir("XDG_CONFIG_HOME", getHomeDir()+"/.config") +
+                 "/aria2/aria2.conf";
+  }
+  return filename;
+}
+
+std::string getDHTFile(bool ipv6) {
+  std::string filename = getHomeDir() + (ipv6 ? "/.aria2/dht6.dat" : "/.aria2/dht.dat");
+  if (!File(filename).exists()) {
+  filename = getXDGDir("XDG_CACHE_HOME", getHomeDir()+"/.cache") +
+             (ipv6 ? "/aria2/dht6.dat" : "/aria2/dht.dat");
+  }
+  return filename;
+}
+
 int64_t getRealSize(const std::string& sizeWithUnit)
 {
   std::string::size_type p = sizeWithUnit.find_first_of("KMkm");

--- a/src/util.h
+++ b/src/util.h
@@ -349,6 +349,13 @@ void setGlobalSignalHandler(int signal, sigset_t* mask,
 
 std::string getHomeDir();
 
+std::string getXDGDir(const std::string& environmentVariable,
+                      const std::string& fallbackDirectory);
+
+std::string getConfigFile();
+
+std::string getDHTFile(bool ipv6);
+
 int64_t getRealSize(const std::string& sizeWithUnit);
 
 std::string abbrevSize(int64_t size);


### PR DESCRIPTION
See http://standards.freedesktop.org/basedir-spec/latest/ for further
details.  This implementation decides the default based on whether a
file exists at the legacy location, if it doesn't, it picks the
XDG-conforming location instead.