### PR TITLE
Send the last error message as part of tellStatus RPC response

### DIFF
--- a/src/AbstractCommand.cc
+++ b/src/AbstractCommand.cc
@@ -343,7 +343,7 @@ bool AbstractCommand::execute()
     return false;
   }
   catch (DlAbortEx& err) {
-    requestGroup_->setLastErrorCode(err.getErrorCode());
+    requestGroup_->setLastErrorCode(err.getErrorCode(), err.what());
     if (req_) {
       A2_LOG_ERROR_EX
         (fmt(MSG_DOWNLOAD_ABORTED, getCuid(), req_->getUri().c_str()),
@@ -376,7 +376,7 @@ bool AbstractCommand::execute()
       A2_LOG_ERROR_EX
         (fmt(MSG_DOWNLOAD_ABORTED, getCuid(), req_->getUri().c_str()), err);
       fileEntry_->addURIResult(req_->getUri(), err.getErrorCode());
-      requestGroup_->setLastErrorCode(err.getErrorCode());
+      requestGroup_->setLastErrorCode(err.getErrorCode(), err.what());
       if (err.getErrorCode() == error_code::CANNOT_RESUME) {
         requestGroup_->increaseResumeFailureCount();
       }
@@ -392,7 +392,7 @@ bool AbstractCommand::execute()
     return prepareForRetry(0);
   }
   catch (DownloadFailureException& err) {
-    requestGroup_->setLastErrorCode(err.getErrorCode());
+    requestGroup_->setLastErrorCode(err.getErrorCode(), err.what());
     if (req_) {
       A2_LOG_ERROR_EX
         (fmt(MSG_DOWNLOAD_ABORTED, getCuid(), req_->getUri().c_str()),

--- a/src/DownloadResult.h
+++ b/src/DownloadResult.h
@@ -92,6 +92,8 @@ struct DownloadResult
 
   error_code::Value result;
 
+  std::string resultMessage;
+
   bool inMemoryDownload;
 
   DownloadResult();

--- a/src/PeerInteractionCommand.cc
+++ b/src/PeerInteractionCommand.cc
@@ -402,7 +402,7 @@ void PeerInteractionCommand::onAbort() {
 
 void PeerInteractionCommand::onFailure(const Exception& err)
 {
-  requestGroup_->setLastErrorCode(err.getErrorCode());
+  requestGroup_->setLastErrorCode(err.getErrorCode(), err.what());
   requestGroup_->setHaltRequested(true);
   getDownloadEngine()->setRefreshInterval(std::chrono::milliseconds(0));
 }

--- a/src/RequestGroup.h
+++ b/src/RequestGroup.h
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <vector>
 #include <memory>
+#include <utility>
 
 #include "TransferStat.h"
 #include "TimeA2.h"
@@ -163,6 +164,8 @@ private:
 
   error_code::Value lastErrorCode_;
 
+  std::string lastErrorMessage_;
+
   bool saveControlFile_;
 
   bool fileAllocationEnabled_;
@@ -195,7 +198,7 @@ private:
   // download didn't finish and error result is available in
   // _uriResults, then last result code is returned.  Otherwise
   // returns error_code::UNKNOWN_ERROR.
-  error_code::Value downloadResult() const;
+  std::pair<error_code::Value, std::string> downloadResult() const;
 
   void removeDefunctControlFile
   (const std::shared_ptr<BtProgressInfoFile>& progressInfoFile);
@@ -478,9 +481,10 @@ public:
     maxUploadSpeedLimit_ = speed;
   }
 
-  void setLastErrorCode(error_code::Value code)
+  void setLastErrorCode(error_code::Value code, const char *message = "")
   {
     lastErrorCode_ = code;
+    lastErrorMessage_ = message;
   }
 
   error_code::Value getLastErrorCode() const

--- a/src/RequestGroupMan.cc
+++ b/src/RequestGroupMan.cc
@@ -516,7 +516,7 @@ void RequestGroupMan::fillRequestGroupFromReserver(DownloadEngine* e)
     } catch(RecoverableException& ex) {
       A2_LOG_ERROR_EX(EX_EXCEPTION_CAUGHT, ex);
       A2_LOG_DEBUG("Deleting temporal commands.");
-      groupToAdd->setLastErrorCode(ex.getErrorCode());
+      groupToAdd->setLastErrorCode(ex.getErrorCode(), ex.what());
       // We add groupToAdd to e later in order to it is processed in
       // removeStoppedGroup().
       requestQueueCheck();

--- a/src/RpcMethodImpl.cc
+++ b/src/RpcMethodImpl.cc
@@ -96,6 +96,7 @@ const char VLB_ZERO[] = "0";
 
 const char KEY_GID[] = "gid";
 const char KEY_ERROR_CODE[] = "errorCode";
+const char KEY_ERROR_MESSAGE[] = "errorMessage";
 const char KEY_STATUS[] = "status";
 const char KEY_TOTAL_LENGTH[] = "totalLength";
 const char KEY_COMPLETED_LENGTH[] = "completedLength";
@@ -811,6 +812,9 @@ void gatherStoppedDownload
   }
   if(requested_key(keys, KEY_ERROR_CODE)) {
     entryDict->put(KEY_ERROR_CODE, util::itos(static_cast<int>(ds->result)));
+  }
+  if(requested_key(keys, KEY_ERROR_MESSAGE)) {
+    entryDict->put(KEY_ERROR_MESSAGE, ds->resultMessage);
   }
   if(requested_key(keys, KEY_STATUS)) {
     if(ds->result == error_code::REMOVED) {


### PR DESCRIPTION
I added a new field "errorMessage" to the aria2.tellStatus JSON-RPC response. It provides more information than just the numeric error code. For example, it contains the HTTP error status code returned from the remote server.