### PR TITLE
Log to stderr instead of stdout.

### DIFF
--- a/src/LogFactory.cc
+++ b/src/LogFactory.cc
@@ -104,7 +104,7 @@ const std::shared_ptr<Logger>& LogFactory::getInstance()
 void LogFactory::setLogFile(const std::string& name)
 {
   if(name == "-") {
-    filename_ = DEV_STDOUT;
+    filename_ = DEV_STDERR;
   } else if(name == "") {
     filename_ = DEV_NULL;
   } else {

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -54,7 +54,7 @@ Logger::Logger()
   : logLevel_(Logger::A2_DEBUG),
     consoleLogLevel_(Logger::A2_NOTICE),
     consoleOutput_(true),
-    colorOutput_(global::cout()->supportsColor())
+    colorOutput_(global::cerr()->supportsColor())
 {}
 
 Logger::~Logger()
@@ -212,11 +212,11 @@ void Logger::writeLog
     fpp_->flush();
   }
   if(consoleLogEnabled(level)) {
-    global::cout()->printf("\n");
-    writeHeaderConsole(*global::cout(), level, colorOutput_);
-    global::cout()->printf("%s\n", msg);
-    writeStackTrace(*global::cout(), trace);
-    global::cout()->flush();
+    global::cerr()->printf("\n");
+    writeHeaderConsole(*global::cerr(), level, colorOutput_);
+    global::cerr()->printf("%s\n", msg);
+    writeStackTrace(*global::cerr(), trace);
+    global::cerr()->flush();
   }
 }
 

--- a/src/a2io.h
+++ b/src/a2io.h
@@ -111,13 +111,15 @@
 # define DEV_NULL "/dev/null"
 #endif // HAVE_WINSOCK2_H
 
-// Use 'con' instead of '/dev/stdin' and '/dev/stdout' in win32.
+// Use 'con' instead of '/dev/stdin' and '/dev/stdout' and '/dev/stderr' in win32.
 #ifdef HAVE_WINSOCK2_H
 # define DEV_STDIN "con"
 # define DEV_STDOUT "con"
+# define DEV_STDERR "con"
 #else
 # define DEV_STDIN "/dev/stdin"
 # define DEV_STDOUT "/dev/stdout"
+# define DEV_STDERR "/dev/stderr"
 #endif // HAVE_WINSOCK2_H
 
 #ifdef __MINGW32__

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -41,7 +41,7 @@
     "                              ignored.")
 #define TEXT_LOG                                                        \
   _(" -l, --log=LOG                The file name of the log file. If '-' is\n" \
-    "                              specified, log is written to stdout.")
+    "                              specified, log is written to stderr.")
 #define TEXT_DAEMON                                                     \
   _(" -D, --daemon[=true|false]    Run as daemon. The current working directory will\n" \
     "                              be changed to \"/\" and standard input, standard\n" \


### PR DESCRIPTION
Hello, 

This is a response to <https://github.com/tatsuhiro-t/aria2/issues/510>. I think logging to stderr is better in general because users can choose what to see from different streams. (Specifically they can use `2>/dev/null` to hide console logs.) I compiled the updated program and it runs correctly, but you may want to double check nothing is left out by this change. Thank you.