### PR TITLE
Updated dependency and source url's

### DIFF
--- a/Dockerfile.raspberrypi
+++ b/Dockerfile.raspberrypi
@@ -1,3 +1,4 @@
+
 FROM ubuntu:trusty
 
 MAINTAINER Igor Khomyakov
@@ -17,7 +18,7 @@ ENV TOOL_BIN_DIR /tools/arm-bcm2708/gcc-linaro-$HOST-raspbian-x64/bin
 ENV PATH ${TOOL_BIN_DIR}:$PATH
 
 RUN mkdir $LOCAL_DIR && mkdir zlib && cd zlib && \
-   curl -Ls -o - 'http://prdownloads.sourceforge.net/libpng/zlib-1.2.8.tar.gz?download'  | \
+   curl -Ls -o - 'http://zlib.net/zlib-1.2.8.tar.gz'  | \
         tar xzf - --strip-components=1 && \
    prefix=${LOCAL_DIR} \
    CC=$HOST-gcc \
@@ -43,7 +44,7 @@ RUN mkdir -p expat && cd expat && \
     make -s install
 
 RUN mkdir c-ares && cd c-ares && \
-    curl -Ls -o -  http://c-ares.haxx.se/download/c-ares-1.10.0.tar.gz | \
+    curl -Ls -o - 'http://c-ares.haxx.se/download/c-ares-1.10.0.tar.gz' | \
         tar xzf - --strip-components=1 && \
     ./configure \
         --host=$HOST \
@@ -55,7 +56,7 @@ RUN mkdir c-ares && cd c-ares && \
     make -s install
 
 RUN mkdir gmp && cd gmp && \
-    curl -Ls -o - 'https://gmplib.org/download/gmp/gmp-6.0.0a.tar.lz' | \
+    curl -Ls -o - 'https://gmplib.org/download/gmp/gmp-6.1.0.tar.lz' | \
         lzip -d | tar xf - --strip-components=1 && \
     ./configure \
         --disable-shared \
@@ -68,7 +69,7 @@ RUN mkdir gmp && cd gmp && \
     make -s install
 
 RUN mkdir sqlite && cd sqlite && \
-    curl -Ls -o - https://www.sqlite.org/2015/sqlite-autoconf-3080900.tar.gz | \
+    curl -Ls -o - 'https://www.sqlite.org/2016/sqlite-autoconf-3100100.tar.gz' | \
         tar xzf - --strip-components=1 && \
     ./configure \
         --disable-shared \
@@ -78,10 +79,11 @@ RUN mkdir sqlite && cd sqlite && \
         --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` && \
     make -s && \
     make -s install
-   
+
 RUN mkdir aria && cd aria && \
-    curl -Ls -o - http://sourceforge.net/projects/aria2/files/latest/download | \
-        tar xjf - --strip-components=1 && \
+    curl -s 'https://api.github.com/repos/tatsuhiro-t/aria2/releases/latest' | \
+        grep 'browser_download_url.*[0-9]\.tar\.bz2' | sed -e 's/^[[:space:]]*//' | \
+        cut -d ' ' -f 2 | xargs -I % curl -Ls -o - '%' | tar xjf - --strip-components=1 && \
     ./configure \
         --host=$HOST \
         --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` \

--- a/Dockerfile.raspberrypi
+++ b/Dockerfile.raspberrypi
@@ -1,4 +1,3 @@
-
 FROM ubuntu:trusty
 
 MAINTAINER Igor Khomyakov


### PR DESCRIPTION
The RaspberryPi Dockerfile had some out-of-date dependency packages and
was downloading an outdated aria2 source from Sourceforge, which
resulted in a build for version 1.19.0.  The new
fetch-latest-release-from-GitHub script I've cooked up should always
work as long as GitHub doesn't change their API and aria2's platform
agnostic releases follow the "{version number}.tar.bz2" naming format.