### PR TITLE
configure.ac: fix autoreconf error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_SUBST(LT_REVISION, 0)
 AC_SUBST(LT_AGE, 0)
 
 AC_CONFIG_MACRO_DIR([m4])
-AM_PATH_CPPUNIT(1.10.2)
+m4_ifdef([AM_PATH_CPPUNIT], [AM_PATH_CPPUNIT(1.10.2)])
 AC_CONFIG_SRCDIR([src/a2io.h])
 AC_CONFIG_HEADERS([config.h])
 
@@ -311,7 +311,12 @@ AM_CONDITIONAL([HAVE_LIBUV], [test "x$have_libuv" = "xyes"])
 
 have_libxml2=no
 if test "x$with_libxml2" = "xyes"; then
-  AM_PATH_XML2([2.6.24], [have_libxml2=yes])
+  m4_ifdef([AM_PATH_XML2], [AM_PATH_XML2([2.6.24], [have_libxml2=yes])], [
+    XML_CPPFLAGS=
+    XML_LIBS=
+    AC_SUBST([XML_CPPFLAGS])
+    AC_SUBST([XML_LIBS])
+  ])
   if test "x$have_libxml2" = "xyes"; then
     AC_DEFINE([HAVE_LIBXML2], [1], [Define to 1 if you have libxml2.])
   elif test "x$with_libxml2_requested" = "xyes"; then
@@ -321,7 +326,12 @@ fi
 
 have_libexpat=no
 if test "x$with_libexpat" = "xyes" && test "x$have_libxml2" != "xyes"; then
-  AM_PATH_LIBEXPAT
+  m4_ifdef([AM_PATH_LIBEXPAT], [AM_PATH_LIBEXPAT], [
+    EXPAT_CFLAGS=
+    EXPAT_LIBS=
+    AC_SUBST([EXPAT_CFLAGS])
+    AC_SUBST([EXPAT_LIBS])
+  ])
   if test "x$have_libexpat" != "xyes" &&
      test "x$with_libexpat_requested" = "xyes"; then
     ARIA2_DEP_NOT_MET([libexpat])
@@ -530,7 +540,12 @@ if test "x$have_openssl" != "xyes"; then
   if test "x$with_libgcrypt" = "xyes" &&
      test "x$have_nativetls" != "xyes" &&
      test "x$have_libnettle" != "xyes"; then
-    AM_PATH_LIBGCRYPT([1.2.4], [have_libgcrypt=yes])
+    m4_ifdef([AM_PATH_LIBGCRYPT], [AM_PATH_LIBGCRYPT([1.2.4], [have_libgcrypt=yes])], [
+      LIBGCRYPT_CFLAGS=
+      LIBGCRYPT_LIBS=
+      AC_SUBST([LIBGCRYPT_CFLAGS])
+      AC_SUBST([LIBGCRYPT_LIBS])
+    ])
     if test "x$have_libgcrypt" = "xyes"; then
       AC_DEFINE([HAVE_LIBGCRYPT], [1], [Define to 1 if you have libgcrypt.])
     fi


### PR DESCRIPTION
Use m4_ifdef so we do not have to install optional libraries