### PR TITLE
Add support for using gnutls system wide crypto policy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,13 @@ AC_ARG_WITH([bashcompletiondir],
 
 AC_ARG_VAR([ARIA2_STATIC], [Set 'yes' to build a statically linked aria2])
 
+AC_ARG_ENABLE([gnutls-system-crypto-policy],
+    AS_HELP_STRING([--enable-gnutls-system-crypto-policy], [Enable gnutls system wide crypto policy]))
+
+AS_IF([test "x$enable_gnutls_system_crypto_policy" = "xyes"], [
+  AC_DEFINE([USE_GNUTLS_SYSTEM_CRYPTO_POLICY], [1], [Define to 1 if using gnutls system wide crypto policy .])
+])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/src/LibgnutlsTLSSession.cc
+++ b/src/LibgnutlsTLSSession.cc
@@ -128,6 +128,9 @@ int GnuTLSSession::init(sock_t sockfd)
   // It seems err is not error message, but the argument string
   // which causes syntax error.
   const char* err;
+#ifdef USE_GNUTLS_SYSTEM_CRYPTO_POLICY
+  rv_ = gnutls_priority_set_direct(sslSession_, "@SYSTEM", &err);
+#else
   std::string pri = "SECURE128:+SIGN-RSA-SHA1";
   switch (tlsContext_->getMinTLSVersion()) {
   case TLS_PROTO_TLS12:
@@ -142,6 +145,7 @@ int GnuTLSSession::init(sock_t sockfd)
     break;
   };
   rv_ = gnutls_priority_set_direct(sslSession_, pri.c_str(), &err);
+#endif  
   if (rv_ != GNUTLS_E_SUCCESS) {
     return TLS_ERR_ERROR;
   }

--- a/src/LibgnutlsTLSSession.cc
+++ b/src/LibgnutlsTLSSession.cc
@@ -145,7 +145,7 @@ int GnuTLSSession::init(sock_t sockfd)
     break;
   };
   rv_ = gnutls_priority_set_direct(sslSession_, pri.c_str(), &err);
-#endif  
+#endif
   if (rv_ != GNUTLS_E_SUCCESS) {
     return TLS_ERR_ERROR;
   }


### PR DESCRIPTION
Hello,

I'm currently maintaining aria2 package for Fedora and EPEL, I carry a small patch to use gnutls system cipher suite as required by packaging guidelines.

I was wondering if you could merge this patch to make updating package easier since it removes the need to rebase the patch every aria2 release.



