### PR TITLE
Report verifiedLength in tellStatus

### DIFF
--- a/src/CheckIntegrityMan.cc
+++ b/src/CheckIntegrityMan.cc
@@ -32,25 +32,22 @@
  * files in the program, then also delete it here.
  */
 /* copyright --> */
-#ifndef D_CHECK_INTEGRITY_MAN_H
-#define D_CHECK_INTEGRITY_MAN_H
-
-#include "common.h"
-#include "SequentialPicker.h"
+#include "CheckIntegrityMan.h"
+#include "CheckIntegrityEntry.h"
 
 namespace aria2 {
 
-class CheckIntegrityEntry;
-class RequestGroup;
+bool CheckIntegrityMan::isPicked(std::shared_ptr<RequestGroup> rg) {
+    return pickedEntry_ && rg && pickedEntry_->getRequestGroup() == rg.get();
+}
 
-class CheckIntegrityMan : public SequentialPicker<CheckIntegrityEntry> {
-public:
-    bool isPicked(std::shared_ptr<RequestGroup> rg);
-    bool isQueued(std::shared_ptr<RequestGroup> rg);
-};
+bool CheckIntegrityMan::isQueued(std::shared_ptr<RequestGroup> rg) {
+    bool found = false;
+    for(auto& e : entries_) {
+        if(e && rg && e->getRequestGroup() == rg.get())
+            found = true;
+    }
+    return found;
+}
 
-// typedef SequentialPicker<CheckIntegrityEntry> CheckIntegrityMan;
-
-} // namespace aria2
-
-#endif // D_CHECK_INTEGRITY_MAN_H
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@ SRCS =  \
 	CheckIntegrityCommand.cc CheckIntegrityCommand.h\
 	CheckIntegrityDispatcherCommand.cc CheckIntegrityDispatcherCommand.h\
 	CheckIntegrityEntry.cc CheckIntegrityEntry.h\
-	CheckIntegrityMan.h\
+	CheckIntegrityMan.cc CheckIntegrityMan.h\
 	Checksum.cc Checksum.h\
 	ChecksumCheckIntegrityEntry.cc ChecksumCheckIntegrityEntry.h\
 	ChunkChecksum.cc ChunkChecksum.h\

--- a/src/RequestGroupEntry.h
+++ b/src/RequestGroupEntry.h
@@ -37,6 +37,7 @@
 
 #include "common.h"
 
+#include "Command.h"
 #include <memory>
 
 namespace aria2 {

--- a/src/RpcMethodImpl.cc
+++ b/src/RpcMethodImpl.cc
@@ -77,6 +77,7 @@
 #include "BtRuntime.h"
 #include "BtAnnounce.h"
 #endif // ENABLE_BITTORRENT
+#include "CheckIntegrityEntry.h"
 
 namespace aria2 {
 
@@ -144,6 +145,8 @@ const char KEY_NUM_WAITING[] = "numWaiting";
 const char KEY_NUM_STOPPED[] = "numStopped";
 const char KEY_NUM_ACTIVE[] = "numActive";
 const char KEY_NUM_STOPPED_TOTAL[] = "numStoppedTotal";
+const char KEY_VERIFIED_LENGTH[] = "verifiedLength";
+const char KEY_VERIFY_PENDING[] = "verifyIntegrityPending";
 } // namespace
 
 namespace {
@@ -793,6 +796,14 @@ void gatherProgress(Dict* entryDict, const std::shared_ptr<RequestGroup>& group,
                              e->getBtRegistry()->get(group->getGID()), keys);
   }
 #endif // ENABLE_BITTORRENT
+  if (e && e->getCheckIntegrityMan()) {
+     if (e->getCheckIntegrityMan()->isPicked(group)) {
+        entryDict->put(KEY_VERIFIED_LENGTH, util::itos(e->getCheckIntegrityMan()->getPickedEntry()->getCurrentLength()));
+     }
+     if (e->getCheckIntegrityMan()->isQueued(group)) {
+        entryDict->put(KEY_VERIFY_PENDING, VLB_TRUE);
+     }
+  }
 }
 } // namespace
 

--- a/src/RpcMethodImpl.h
+++ b/src/RpcMethodImpl.h
@@ -54,6 +54,7 @@ namespace aria2 {
 
 struct DownloadResult;
 class RequestGroup;
+class CheckIntegrityEntry;
 
 namespace rpc {
 

--- a/src/SequentialPicker.h
+++ b/src/SequentialPicker.h
@@ -43,7 +43,7 @@
 namespace aria2 {
 
 template <typename T> class SequentialPicker {
-private:
+protected:
   std::deque<std::unique_ptr<T>> entries_;
   std::unique_ptr<T> pickedEntry_;
 


### PR DESCRIPTION
Allows RPC clients to view progress of the check integrity step.

I didn't notice any tests for TellStatus so I havn't tried to make any for this branch. One other modification I would like to make but wasn't sure how to implement would be reporting if a particular download was in the queue to have its integrity checked (in the CheckIntegrityMan deque). If you had any thoughts on how to do that I'd be happy to implement it.

Please also provide any feedback or changes you like to see made to this PR to be merged.

